### PR TITLE
Death table

### DIFF
--- a/R/LoadEventTables.r
+++ b/R/LoadEventTables.r
@@ -30,7 +30,7 @@ LoadEventTables <- function (connectionDetails, cdmDatabaseSchema, syntheaDataba
 
     queries <- c("insert_person.sql", "insert_observation_period.sql", "insert_visit_occurrence.sql", "insert_condition_occurrence.sql",
                  "insert_observation.sql", "insert_measurement.sql", "insert_procedure_occurrence.sql", "insert_drug_exposure.sql",
-				 "insert_condition_era.sql", "insert_drug_era.sql", "insert_cdm_source.sql")
+                 "insert_death.sql", "insert_condition_era.sql", "insert_drug_era.sql", "insert_cdm_source.sql")
 
 	conn <- DatabaseConnector::connect(connectionDetails)
 

--- a/docs/Death.md
+++ b/docs/Death.md
@@ -1,0 +1,25 @@
+---
+layout: default
+title: Death
+nav_order: 2
+description: "Death mapping from cdm person"
+
+---
+
+# Death
+
+## Reading from OMOP CDM table person
+
+Filter
+ 
+ - person.death_datetime is not null 
+
+| Destination Field | Source field | Logic | Comment field |
+| --- | --- | --- | --- |
+| person_id | person_id |  |  |
+| death_date | death_datetime |  |  |
+| death_datetime | death_datetime | |  |
+| death_type_concept_id |  | 38003569 | EHR record patient status "Deceased" |
+| cause_concept_id |  |  |  |
+| cause_source_value |  |  |  |
+| cause_source_concept_id |  |  |  |

--- a/inst/sql/sql_server/create_event_tables.sql
+++ b/inst/sql/sql_server/create_event_tables.sql
@@ -138,6 +138,19 @@ CREATE TABLE @cdm_schema.specimen
 )
 ;
 
+if object_id('@cdm_schema.death', 'U')  is not null drop table @cdm_schema.death;
+--HINT DISTRIBUTE_ON_KEY(person_id)
+CREATE TABLE @cdm_schema.death (
+    person_id               INTEGER     NOT NULL,
+    death_date              DATE        NOT NULL,
+    death_datetime          TIMESTAMP   NULL,
+    death_type_concept_id   INTEGER     NOT NULL,
+    cause_concept_id        INTEGER     NULL,
+    cause_source_value      VARCHAR(50) NULL,
+    cause_source_concept_id INTEGER     NULL
+)
+;
+
 if object_id('@cdm_schema.visit_occurrence', 'U')  is not null drop table @cdm_schema.visit_occurrence;
 --HINT DISTRIBUTE_ON_KEY(person_id)
 CREATE TABLE @cdm_schema.visit_occurrence

--- a/inst/sql/sql_server/insert_death.sql
+++ b/inst/sql/sql_server/insert_death.sql
@@ -1,0 +1,21 @@
+INSERT INTO @cdm_schema.death
+(
+    person_id,
+    death_date,
+    death_datetime,
+    death_type_concept_id,
+    cause_concept_id,
+    cause_source_value,
+    cause_source_concept_id
+)
+SELECT
+    person_id,
+    death_datetime,
+    death_datetime,
+    38003569,
+    NULL,
+    NULL,
+    NULL
+FROM @cdm_schema.person
+WHERE person.death_datetime IS NOT NULL
+;

--- a/inst/sql/sql_server/insert_person.sql
+++ b/inst/sql/sql_server/insert_person.sql
@@ -6,6 +6,7 @@ year_of_birth,
 month_of_birth,
 day_of_birth,
 birth_datetime,
+death_datetime,
 race_concept_id,
 ethnicity_concept_id,
 location_id,
@@ -29,6 +30,7 @@ select
 	MONTH(p.birthdate),
 	DAY(p.birthdate),
 	p.birthdate,
+    p.deathdate,
 	case upper(p.race)
 		when 'WHITE' then 8527
 		when 'BLACK' then 8516


### PR DESCRIPTION
Adds the death table (required in v5.3) and implements mapping of patient death date. The mapping is implemented for both the already documented death_datetime field (v6) in person AND for the death table. The latter simply copies the death_datetime in person table for deceased patients.