### PR TITLE
for 5.3.1, restored sequence, replaced use of multiple row_number() calls see issue #67

### DIFF
--- a/inst/sql/sql_server/insert_drug_exposure.sql
+++ b/inst/sql/sql_server/insert_drug_exposure.sql
@@ -1,3 +1,5 @@
+drop sequence if exists drug_exposure_id_seq;
+create sequence drug_exposure_id_seq start with 1;
 
 
 insert into @cdm_schema.drug_exposure (
@@ -26,7 +28,7 @@ route_source_value,
 dose_unit_source_value
 )
 select
-row_number()over(order by p.person_id),
+nextval('drug_exposure_id_seq'),
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 c.start,
@@ -68,7 +70,7 @@ join @cdm_schema.person p
 union all
 
 select
-row_number()over(order by p.person_id),
+nextval('drug_exposure_id_seq'),
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 m.start,
@@ -109,7 +111,7 @@ join @cdm_schema.person p
 union all
 
 select
-row_number()over(order by p.person_id),
+nextval('drug_exposure_id_seq'),
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 i.date,

--- a/inst/sql/sql_server/insert_measurement.sql
+++ b/inst/sql/sql_server/insert_measurement.sql
@@ -1,3 +1,5 @@
+drop sequence if exists measurement_id_seq;
+create sequence measurement_id_seq start with 1;
 
 
 insert into @cdm_schema.measurement (
@@ -23,7 +25,7 @@ unit_source_value,
 value_source_value
 )
 select
-row_number()over(order by p.person_id),
+nextval('measurement_id_seq'),
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 pr.date,
@@ -61,7 +63,7 @@ join @cdm_schema.person p
 union all
 
 select
-row_number()over(order by p.person_id),
+nextval('measurement_id_seq'),
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 o.date,

--- a/inst/sql/sql_server/insert_observation.sql
+++ b/inst/sql/sql_server/insert_observation.sql
@@ -1,4 +1,9 @@
 
+drop sequence if exists observation_id_seq;
+create sequence observation_id_seq start with 1;
+
+
+
 insert into @cdm_schema.observation (
 observation_id,
 person_id,
@@ -20,7 +25,7 @@ unit_source_value,
 qualifier_source_value
 )
 select
-row_number()over(order by p.person_id),
+nextval('observation_id_seq'), 
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 a.start,
@@ -56,7 +61,7 @@ join @cdm_schema.person p
 union all
 
 select
-row_number()over(order by p.person_id),
+nextval('observation_id_seq'), 
 p.person_id,
 case when srctostdvm.target_concept_id is NULL then 0 else srctostdvm.target_concept_id end as target_concept_id,
 c.start,


### PR DESCRIPTION
…insert from a union that resulted in a duplicate key violation.

Please review as I don't know the intent of the original commit mentioned in the issue, nor do I have other databases to test this against.

