### PR TITLE
fix(v6): admitting_* to admitted_from_* attr in visit detail table

### DIFF
--- a/inst/sql/sql_server/cdm_version/v600/insert_visit_detail.sql
+++ b/inst/sql/sql_server/cdm_version/v600/insert_visit_detail.sql
@@ -13,12 +13,12 @@ insert into @cdm_schema.visit_detail (
   visit_detail_type_concept_id,
   provider_id,
   care_site_id,
-  admitted_source_concept_id,
+  admitted_from_concept_id,
   discharge_to_concept_id,
   preceding_visit_detail_id,
   visit_detail_source_value,
   visit_detail_source_concept_id,
-  admitted_source_value,
+  admitted_from_source_value,
   discharge_to_source_value,
   visit_detail_parent_id,
   visit_occurrence_id
@@ -45,14 +45,14 @@ select
 	44818517                             visit_detail_type_concept_id,                             
 	0                                    provider_id,                                 
 	null                                 care_site_id,                                 
-	0                                    admitted_source_concept_id,
+	0                                    admitted_from_concept_id,
 	0                                    discharge_to_concept_id,                                       
     lag(av.visit_occurrence_id) 
 	over(partition by p.person_id
 			 order by av.visit_start_date) + 1000000 preceding_visit_detail_id,
 	av.encounter_id                                  visit_detail_source_value,
 	0                                                visit_detail_source_concept_id,                                
-	null                                             admitted_source_value,
+	null                                             admitted_from_source_value,
 	null                                             discharge_to_source_value,
 	null                                             visit_detail_parent_id,
 	av.visit_occurrence_id                           visit_occurrence_id

--- a/inst/sql/sql_server/cdm_version/v600/insert_visit_detail.sql
+++ b/inst/sql/sql_server/cdm_version/v600/insert_visit_detail.sql
@@ -13,12 +13,12 @@ insert into @cdm_schema.visit_detail (
   visit_detail_type_concept_id,
   provider_id,
   care_site_id,
-  admitting_source_concept_id,
+  admitted_source_concept_id,
   discharge_to_concept_id,
   preceding_visit_detail_id,
   visit_detail_source_value,
   visit_detail_source_concept_id,
-  admitting_source_value,
+  admitted_source_value,
   discharge_to_source_value,
   visit_detail_parent_id,
   visit_occurrence_id
@@ -45,14 +45,14 @@ select
 	44818517                             visit_detail_type_concept_id,                             
 	0                                    provider_id,                                 
 	null                                 care_site_id,                                 
-	0                                    admitting_source_concept_id,
+	0                                    admitted_source_concept_id,
 	0                                    discharge_to_concept_id,                                       
     lag(av.visit_occurrence_id) 
 	over(partition by p.person_id
 			 order by av.visit_start_date) + 1000000 preceding_visit_detail_id,
 	av.encounter_id                                  visit_detail_source_value,
 	0                                                visit_detail_source_concept_id,                                
-	null                                             admitting_source_value,   
+	null                                             admitted_source_value,
 	null                                             discharge_to_source_value,
 	null                                             visit_detail_parent_id,
 	av.visit_occurrence_id                           visit_occurrence_id


### PR DESCRIPTION
## Description
Insertion to the `visit detail` table fails since `admitting_source_value` and `admitting_source_concept_id` have been updated to `admitted_from_source_value` and `admitted_from_concept_id` in CDM v6.