### PR TITLE
Resolve Bug around versioning 5.3.1

### DIFF
--- a/R/CreateVisitRollupTables.r
+++ b/R/CreateVisitRollupTables.r
@@ -4,13 +4,13 @@
 #'
 #' @usage CreateVisitRollupTables (connectionDetails, cdmSchema, syntheaSchema, cdmVersion, sqlOnly)
 #'
-#' @details This function assumes \cr\code{createCDMTables()}, \cr\code{createSyntheaTables()}, \cr\code{LoadSyntheaTables()}, 
-#'          have all been run and the Vocabulary has been loaded.  
+#' @details This function assumes \cr\code{createCDMTables()}, \cr\code{createSyntheaTables()}, \cr\code{LoadSyntheaTables()},
+#'          have all been run and the Vocabulary has been loaded.
 #'
 #' @param connectionDetails  An R object of type\cr\code{connectionDetails} created using the
 #'                                     function \code{createConnectionDetails} in the
 #'                                     \code{DatabaseConnector} package.
-#' @param cdmSchema  The name of the database schema that will contain the different VISIT 
+#' @param cdmSchema  The name of the database schema that will contain the different VISIT
 #'                                     tables.  Requires read and write permissions to this database. On SQL
 #'                                     Server, this should specifiy both the database and the schema,
 #'                                     so for example 'cdm_instance.dbo'.
@@ -27,21 +27,21 @@
 CreateVisitRollupTables <- function (connectionDetails, cdmSchema, syntheaSchema, cdmVersion, sqlOnly = FALSE)
 {
 
-	if (cdmVersion == "5.3")
+	if (cdmVersion == "5.3.1")
 		sqlFilePath <- "cdm_version/v531"
 	else if (cdmVersion == "5.4")
 		sqlFilePath <- "cdm_version/v540"
 	else
-		stop("Unsupported CDM specified. Supported CDM versions are \"5.3\" and \"5.4\"")
+		stop("Unsupported CDM specified. Supported CDM versions are \"5.3.1\" and \"5.4\"")
 
     queries <- c("AllVisitTable.sql", "AAVITable.sql", "final_visit_ids.sql")
 
 	if (!sqlOnly) {
-		conn <- DatabaseConnector::connect(connectionDetails) 
+		conn <- DatabaseConnector::connect(connectionDetails)
     }
-	
+
 	for (query in queries) {
-	
+
 		translatedSql <- SqlRender::loadRenderTranslateSql(
 			sqlFilename    = paste0(sqlFilePath,"/",query),
 			packageName    = "ETLSyntheaBuilder",
@@ -53,12 +53,12 @@ CreateVisitRollupTables <- function (connectionDetails, cdmSchema, syntheaSchema
 		if (sqlOnly) {
 			if (!dir.exists("output"))
 				dir.create("output")
-				
+
 			writeLines(paste0("Saving to output/", query))
 			SqlRender::writeSql(translatedSql,paste0("output/",query))
 
         } else {
-			writeLines(paste0("Running: ",query))		
+			writeLines(paste0("Running: ",query))
 			DatabaseConnector::executeSql(conn, translatedSql)
 		}
     }

--- a/R/CreateVocabMapTables.r
+++ b/R/CreateVocabMapTables.r
@@ -4,12 +4,12 @@
 #'
 #' @usage CreateVocabMapTables (connectionDetails, cdmSchema, cdmVersion, sqlOnly)
 #'
-#' @details This function assumes \cr\code{createCDMTables()} has already been run and the Vocabulary tables have been loaded.  
+#' @details This function assumes \cr\code{createCDMTables()} has already been run and the Vocabulary tables have been loaded.
 #'
 #' @param connectionDetails  An R object of type\cr\code{connectionDetails} created using the
 #'                                     function \code{createConnectionDetails} in the
 #'                                     \code{DatabaseConnector} package.
-#' @param cdmSchema  The name of the database schema that will contain the Vocab mapping 
+#' @param cdmSchema  The name of the database schema that will contain the Vocab mapping
 #'                                     tables.  Requires read and write permissions to this database. On SQL
 #'                                     Server, this should specifiy both the database and the schema,
 #'                                     so for example 'cdm_instance.dbo'.
@@ -22,21 +22,21 @@
 CreateVocabMapTables <- function (connectionDetails, cdmSchema, cdmVersion, sqlOnly = FALSE)
 {
 
-	if (cdmVersion == "5.3")
+	if (cdmVersion == "5.3.1")
 		sqlFilePath <- "cdm_version/v531"
 	else if (cdmVersion == "5.4")
 		sqlFilePath <- "cdm_version/v540"
 	else
-		stop("Unsupported CDM specified. Supported CDM versions are \"5.3\" and \"5.4\"")
+		stop("Unsupported CDM specified. Supported CDM versions are \"5.3.1\" and \"5.4\"")
 
     queries <- c("create_source_to_standard_vocab_map.sql", "create_source_to_source_vocab_map.sql")
-    
+
 	if (!sqlOnly) {
-		conn <- DatabaseConnector::connect(connectionDetails) 
+		conn <- DatabaseConnector::connect(connectionDetails)
 	}
-	
+
 	for (query in queries) {
-	
+
 		translatedSql <- SqlRender::loadRenderTranslateSql(
 			sqlFilename    = paste0(sqlFilePath,"/",query),
 			packageName    = "ETLSyntheaBuilder",
@@ -46,12 +46,12 @@ CreateVocabMapTables <- function (connectionDetails, cdmSchema, cdmVersion, sqlO
 		if (sqlOnly) {
 			if (!dir.exists("output"))
 				dir.create("output")
-				
+
 			writeLines(paste0("Saving to output/", query))
 			SqlRender::writeSql(translatedSql,paste0("output/",query))
 
         } else {
-			writeLines(paste0("Running: ",query))		
+			writeLines(paste0("Running: ",query))
 			DatabaseConnector::executeSql(conn, translatedSql)
 		}
     }

--- a/R/DropSyntheaTables.r
+++ b/R/DropSyntheaTables.r
@@ -19,13 +19,13 @@
 DropSyntheaTables <- function (connectionDetails, syntheaSchema)
 {
 
-	syntheaTables <- c( 
+	syntheaTables <- c(
 		"ALLERGIES","CAREPLANS","CONDITIONS","DEVICES","ENCOUNTERS","IMAGING_STUDIES","IMMUNIZATIONS",
 		"MEDICATIONS","OBSERVATIONS","ORGANIZATIONS","PATIENTS","PROCEDURES","PROVIDERS")
 
-	conn <- DatabaseConnector::connect(connectionDetails) 
+	conn <- DatabaseConnector::connect(connectionDetails)
 	allTables <- DatabaseConnector::getTableNames(conn,syntheaSchema)
-	writeLines("Dropping Synthea tables...")		
+	writeLines("Dropping Synthea tables...")
 	tablesToDrop <- allTables[which(allTables %in% syntheaTables)]
 	sql <- paste("drop table @synthea_schema.",tablesToDrop,";",collapse = "\n", sep = "")
 	sql <- SqlRender::render(sql, synthea_schema = syntheaSchema)

--- a/R/LoadEventTables.r
+++ b/R/LoadEventTables.r
@@ -19,7 +19,7 @@
 #'                                     Server, this should specifiy both the database and the schema,
 #'                                     so for example 'cdm_instance.dbo'.
 #' @param cdmVersion The version of your CDM.  Currently "5.3" and "5.4".
-#' @param syntheaVersion The version of Synthea used to generate the csv files.  
+#' @param syntheaVersion The version of Synthea used to generate the csv files.
 #'                       Currently "2.7.0" is supported.
 #' @param sqlOnly A boolean that determines whether or not to perform the load or generate SQL scripts. Default is FALSE.
 #'
@@ -36,12 +36,12 @@ LoadEventTables <- function (connectionDetails,
 
 	# Determine which sql scripts to run based on the given version.
 	# The path is relative to inst/sql/sql_server.
-	if (cdmVersion == "5.3") {
+	if (cdmVersion == "5.3.1") {
 		sqlFilePath <- "cdm_version/v531"
 	} else if (cdmVersion == "5.4") {
 		sqlFilePath <- "cdm_version/v540"
 	} else {
-		stop("Unsupported CDM specified. Supported CDM versions are \"5.3\" and \"5.4\"")
+		stop("Unsupported CDM specified. Supported CDM versions are \"5.3.1\" and \"5.4\"")
 	}
 
     supportedSyntheaVersions <- c("2.7.0")

--- a/R/backupCDM.r
+++ b/R/backupCDM.r
@@ -7,7 +7,7 @@
 #' @param connectionDetails  An R object of type\cr\code{connectionDetails} created using the
 #'                                     function \code{createConnectionDetails} in the
 #'                                     \code{DatabaseConnector} package.
-#' @param cdmSchema  The name of the database schema that contains the CDM.  
+#' @param cdmSchema  The name of the database schema that contains the CDM.
 #'                           Requires read and write permissions to this database. On SQL
 #'                           Server, this should specifiy both the database and the schema,
 #'                           so for example 'cdm_instance.dbo'.
@@ -27,13 +27,12 @@ backupCDM <- function (connectionDetails, cdmSchema, cdmVersion)
 
 
     sql <- SqlRender::loadRenderTranslateSql(
-			sqlFileName = paste0(sqlFilePath,"/backup_cdm.sql"), 
-			packageName = "ETLSyntheaBuilder", 
-			dbms        = connectionDetails$dbms, 
+			sqlFileName = paste0(sqlFilePath,"/backup_cdm.sql"),
+			packageName = "ETLSyntheaBuilder",
+			dbms        = connectionDetails$dbms,
 			cdm_schema  = cdmSchema
 			)
 	conn <- DatabaseConnector::connect(connectionDetails)
     DatabaseConnector::executeSql(conn, sql)
     on.exit(DatabaseConnector::disconnect(conn))
 }
-


### PR DESCRIPTION
Some R scripts have changed to not support CDM version 5.3.1 anymore. This results in the following error:

```
[1] "Performing Synthea ETL"
Caught an error!
<simpleError in ETLSyntheaBuilder::LoadEventTables(connectionDetails = cd, cdmSchema = cdm_schema_full,     syntheaSchema = synthea_schema_full, cdmVersion = cdm_version,     syntheaVersion = synthea_version): Unsupported CDM specified. Supported CDM versions are "5.3" and "5.4">
All done, quitting.
```