### PR TITLE
Remove incorrect gap_days calculation

### DIFF
--- a/inst/sql/sql_server/cdm_version/v531/insert_drug_era.sql
+++ b/inst/sql/sql_server/cdm_version/v531/insert_drug_era.sql
@@ -154,7 +154,7 @@ SELECT
 	, MIN(drug_sub_exposure_start_date) AS drug_era_start_date
 	, drug_era_end_date
 	, SUM(drug_exposure_count) AS drug_exposure_count
-	, datediff(d,'1970-01-01',dateadd(day,-(datediff(day,MIN(drug_sub_exposure_start_date),drug_era_end_date)-SUM(days_exposed)),drug_era_end_date)) as gap_days
+	, datediff(day,MIN(drug_sub_exposure_start_date),drug_era_end_date)-SUM(days_exposed) as gap_days
 INTO #tmp_de
 FROM cteDrugEraEnds dee
 GROUP BY person_id, drug_concept_id, drug_era_end_date;

--- a/inst/sql/sql_server/cdm_version/v540/insert_drug_era.sql
+++ b/inst/sql/sql_server/cdm_version/v540/insert_drug_era.sql
@@ -154,7 +154,7 @@ SELECT
 	, MIN(drug_sub_exposure_start_date) AS drug_era_start_date
 	, drug_era_end_date
 	, SUM(drug_exposure_count) AS drug_exposure_count
-	, datediff(d,'1970-01-01',dateadd(day,-(datediff(day,MIN(drug_sub_exposure_start_date),drug_era_end_date)-SUM(days_exposed)),drug_era_end_date)) as gap_days
+	, datediff(day,MIN(drug_sub_exposure_start_date),drug_era_end_date)-SUM(days_exposed) as gap_days
 INTO #tmp_de
 FROM cteDrugEraEnds dee
 GROUP BY person_id, drug_concept_id, drug_era_end_date;


### PR DESCRIPTION
The gap_days calculation in DRUG_ERA was using 1970-01-01 as a residual artifact from sqlRender and postgresql. This removes it and corrects the calculation.