### PR TITLE
Fix exportToSQLite errors caused by old table name and parameter order

### DIFF
--- a/R/exportToSQLite.r
+++ b/R/exportToSQLite.r
@@ -29,7 +29,6 @@ exportToSQLite <-
       "care_site",
       "cdm_source",
       "cohort",
-      "cohort_attribute",
       "condition_era",
       "condition_occurrence",
       "cost",
@@ -72,10 +71,10 @@ exportToSQLite <-
       sqlQuery <-
         paste0("select * from  ", paste0(cdmSchema, ".", tableName), ";")
       translatedSql <-
-        SqlRender::translate(renderedSql, targetDialect = connectionDetails$dbms)
+        SqlRender::translate(sql=sqlQuery, targetDialect = connectionDetails$dbms)
       writeLines(paste0("Fetching: ", tableName))
-      tableData <- DatabaseConnector::querySql(conn, translatedSql)
-      DatabaseConnector::insertTable(sqliteCon, toupper(tableName), tableData)
+      tableData <- DatabaseConnector::querySql(connection=conn, sql=translatedSql)
+      DatabaseConnector::insertTable(connection=sqliteCon, tableName=toupper(tableName), data=tableData)
     }
 
     DatabaseConnector::disconnect(conn)


### PR DESCRIPTION
I was having issues with the exportToSQLite function and had to make these changes to get it to work. I assume the issue was that this function is using an old CDM table name (cohort_attribute?) and some parameter orders have changed. Either that or I'm not doing something right on my end. 