### PR TITLE
Update v5.3 insert for device exposure based on field length issue

### DIFF
--- a/inst/sql/sql_server/cdm_version/v531/insert_device_exposure.sql
+++ b/inst/sql/sql_server/cdm_version/v531/insert_device_exposure.sql
@@ -26,7 +26,7 @@ d.start                                     device_exposure_start_datetime,
 d.stop                                      device_exposure_end_date,
 d.stop                                      device_exposure_end_datetime,
 32827                                    device_type_concept_id,
-d.udi                                       unique_device_id,
+left(d.udi,50)                                       unique_device_id,
 cast(null as int)                           quantity,
 pr.provider_id                              provider_id,
 fv.visit_occurrence_id_new                  visit_occurrence_id,
@@ -50,7 +50,7 @@ left join @cdm_schema.final_visit_ids fv
 left join @synthea_schema.encounters e
   on d.encounter                        = e.id
  and d.patient                          = e.patient
-left join @cdm_schema.provider pr 
+left join @cdm_schema.provider pr
   on e.provider                         = pr.provider_source_value
 join @cdm_schema.person p
   on p.person_source_value              = d.patient


### PR DESCRIPTION
Fixes #157 

The UDI field length was updated to 255 in the OMOP CDM version 5.4 due to accomodate the length of a standard UDI field as set by the [FDA](https://www.fda.gov/medical-devices/device-advice-comprehensive-regulatory-assistance/unique-device-identification-system-udi-system). In the synthea package, this guidance is being used to generate [synthetic UDIs](https://github.com/synthetichealth/synthea/blob/16ee9bcb6d983c35fc4c9399fd5c464a2760029a/src/main/java/org/mitre/synthea/world/concepts/HealthRecord.java#L537). However, the etl-synthea script was not updated to reflect that version 5.3 of the OMOP CDM maintains that the UDI field length is 50 characters. This update truncates the source data to 50 characters to allow the ETL to successfully complete.